### PR TITLE
`createSecureEnvironment(options?)` refactor

### DIFF
--- a/examples/errors.js
+++ b/examples/errors.js
@@ -9,7 +9,10 @@ const distortionMap = new Map([
 globalThis.bar = { a: 1, b: 2 };
 Object.freeze(globalThis.bar)
 
-const evalScript = createSecureEnvironment(distortionMap, window);
+const evalScript = createSecureEnvironment({
+    distortionMap,
+    endowments: window
+});
 
 try {
     evalScript(`

--- a/examples/getter-distortion.js
+++ b/examples/getter-distortion.js
@@ -10,7 +10,7 @@ const distortionMap = new Map([
     }],
 ]);
 
-const evalScript = createSecureEnvironment(distortionMap);
+const evalScript = createSecureEnvironment({ distortionMap });
 
 evalScript(`
     debugger;

--- a/examples/invalid-fetch.js
+++ b/examples/invalid-fetch.js
@@ -9,7 +9,10 @@ const distortionMap = new Map([
         console.error('forbidden');
     }],
 ]);
-const evalScript = createSecureEnvironment(distortionMap, window);
+const evalScript = createSecureEnvironment({
+    distortionMap,
+    endowments: window
+});
 
 evalScript(`
     debugger;

--- a/examples/web-components/platform.js
+++ b/examples/web-components/platform.js
@@ -10,7 +10,7 @@ distortionMap.set(assignedNodes, _ => { throw new Error(`Forbidden`); });
 distortionMap.set(assignedElements, _ => { throw new Error(`Forbidden`); });
 
 function evaluateInNewSandbox(sourceText) {
-    const evalScript = createSecureEnvironment(distortionMap);
+    const evalScript = createSecureEnvironment({ distortionMap });
     evalScript(sourceText);
 }
 

--- a/src/__tests__/error.spec.ts
+++ b/src/__tests__/error.spec.ts
@@ -24,7 +24,7 @@ globalThis.foo = {
 describe('The Error Boundary', () => {
     it('should preserve identity of errors after a membrane roundtrip', function() {
         expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`foo.expose(() => { foo.a })`);
         expect(() => {
             sandboxedValue();
@@ -40,7 +40,7 @@ describe('The Error Boundary', () => {
     });
     it('should remap the Blue Realm Error instance to the sandbox errors', function() {
         expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
 
         evalScript(`
             expect(() => {
@@ -60,7 +60,7 @@ describe('The Error Boundary', () => {
     });
     it('should capture throwing from user proxy', function() {
         expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             const revocable = Proxy.revocable(() => undefined, {});
             revocable.revoke();
@@ -77,7 +77,7 @@ describe('The Error Boundary', () => {
         }).toThrowError(Error);
     });
     it('should protect from leaking sandbox errors during evaluation', function() {
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         
         expect(() => {
             evalScript(`
@@ -86,7 +86,7 @@ describe('The Error Boundary', () => {
         }).toThrowError(TypeError);
     });
     it('should protect from leaking sandbox errors during parsing', function() {
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
 
         expect(() => {
             evalScript(`

--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -6,7 +6,7 @@ describe('Freezing', () => {
             expect.assertions(10);
             globalThis.bar = { a: 1, b: 2 };
             Object.freeze(globalThis.bar)
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             // checking the state of bar in the blue realm
             expect(Object.isExtensible(globalThis.bar)).toBe(false);
             expect(Object.isSealed(globalThis.bar)).toBe(true);
@@ -49,7 +49,7 @@ describe('Freezing', () => {
         it('should not be observed from within the sandbox after a mutation', function() {
             expect.assertions(9);
             globalThis.baz = { a:1, b: 2 };
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             // checking the state of bar in the sandbox
             evalScript(`
                 expect(Object.isExtensible(globalThis.baz)).toBe(true);
@@ -87,7 +87,7 @@ describe('Freezing', () => {
                     o.z = 3;
                 }).toThrowError();
             }
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             evalScript(`
                 'use strict';
                 const o = { x: 1 };

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -12,7 +12,7 @@ describe('SecureEnvironment', () => {
                 expect(a2 instanceof Array).toBe(true);
                 expect(a2).toStrictEqual([3, 4]);
             }
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             evalScript(`blueArrayFactory([1, 2], new Array(3, 4))`);
         });
         it('should not have identity discontinuity for objects', function() {
@@ -25,7 +25,7 @@ describe('SecureEnvironment', () => {
                 expect(b2 instanceof Object).toBe(true);
                 expect(b2.x).toBe(2);
             }
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             evalScript(`blueObjectFactory({ x: 1 }, Object.create({}, { x: { value: 2 } }))`);
         });
     });
@@ -38,7 +38,7 @@ describe('SecureEnvironment', () => {
         };
         it('should not have identity discontinuity for arrays', function() {
             expect.assertions(6);
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             evalScript(`
                 const { a1, a2 } = foo;
                 expect(Array.isArray(a1)).toBe(true);
@@ -51,7 +51,7 @@ describe('SecureEnvironment', () => {
         });
         it('should not have identity discontinuity for objects', function() {
             expect.assertions(6);
-            const evalScript = createSecureEnvironment(undefined, window);
+            const evalScript = createSecureEnvironment({ endowments: window });
             evalScript(`
                 const { b1, b2 } = foo;
                 expect(typeof b1 === 'object').toBe(true);

--- a/src/__tests__/reflection.spec.ts
+++ b/src/__tests__/reflection.spec.ts
@@ -8,7 +8,7 @@ globalThis.foo = {
 describe('Reflective Intrinsic Objects', () => {
     it('should preserve identity of Object thru membrane', function() {
         expect.assertions(2);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             const o = {};
             expect(foo instanceof Object).toBe(true);
@@ -17,7 +17,7 @@ describe('Reflective Intrinsic Objects', () => {
     });
     it('should preserve identity of Function thru membrane', function() {
         expect.assertions(2);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             function x() {}
             expect(foo.b instanceof Function).toBe(true);
@@ -26,7 +26,7 @@ describe('Reflective Intrinsic Objects', () => {
     });
     it('should preserve identity of Error thru membrane', function() {
         expect.assertions(2);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             const e = new Error();
             expect(foo.e instanceof Error).toBe(true);

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -1,5 +1,5 @@
 import { SecureEnvironment } from "./environment";
-import { RedProxyTarget } from "./types";
+import { EnvironmentOptions } from "./types";
 import { unapply, ReflectGetOwnPropertyDescriptor } from "./shared";
 import { linkIntrinsics, getFilteredEndowmentDescriptors } from "./intrinsics";
 import { getCachedReferences, linkUnforgeables, tameDOM } from "./window";
@@ -65,7 +65,12 @@ function removeIframe(iframe: HTMLIFrameElement) {
     }
 }
 
-export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarget, RedProxyTarget>, endowments?: object): (sourceText: string) => void {
+interface BrowserEnvironmentOptions extends EnvironmentOptions {
+    keepAlive?: boolean;
+}
+
+export default function createSecureEnvironment(options?: BrowserEnvironmentOptions): (sourceText: string) => void {
+    const { distortionMap, endowments, keepAlive } = options || {};
     const iframe = createDetachableIframe();
     const blueWindow = window;
     const redWindow = (iframe.contentWindow as WindowProxy).window;
@@ -83,8 +88,11 @@ export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarg
     linkIntrinsics(env, blueWindow, redWindow);
     linkUnforgeables(env, blueRefs, redRefs);
     tameDOM(env, blueRefs, redRefs, endowmentsDescriptors);
-    // once we get the iframe info ready, and all mapped, we can proceed to detach the iframe
-    removeIframe(iframe);
+    // once we get the iframe info ready, and all mapped, we can proceed
+    // to detach the iframe only if the keepAlive option isn't true
+    if (keepAlive !== true) {
+        removeIframe(iframe);
+    }
     // finally, we return the evaluator function
     return (sourceText: string): void => {
         try {

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -70,7 +70,7 @@ interface BrowserEnvironmentOptions extends EnvironmentOptions {
 }
 
 export default function createSecureEnvironment(options?: BrowserEnvironmentOptions): (sourceText: string) => void {
-    const { distortionMap, endowments, keepAlive } = options || {};
+    const { distortionMap, endowments, keepAlive } = options || ObjectCreate(null);
     const iframe = createDetachableIframe();
     const blueWindow = window;
     const redWindow = (iframe.contentWindow as WindowProxy).window;

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -9,7 +9,7 @@ import { getFilteredEndowmentDescriptors, linkIntrinsics } from "./intrinsics";
 const unsafeGlobalEvalSrc = `(0, eval)("'use strict'; this")`;
 
 export default function createSecureEnvironment(options?: EnvironmentOptions): (sourceText: string) => void {
-    const { distortionMap, endowments } = options || {};
+    const { distortionMap, endowments } = options || ObjectCreate(null);
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
     const redGlobalThis = runInNewContext(unsafeGlobalEvalSrc);
     const endowmentsDescriptors = getFilteredEndowmentDescriptors(endowments || {});

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,5 +1,5 @@
 import { SecureEnvironment } from "./environment";
-import { RedProxyTarget } from "./types";
+import { EnvironmentOptions } from "./types";
 import { runInNewContext } from 'vm';
 import { getFilteredEndowmentDescriptors, linkIntrinsics } from "./intrinsics";
 
@@ -8,7 +8,8 @@ import { getFilteredEndowmentDescriptors, linkIntrinsics } from "./intrinsics";
 // 'this' will be the correct global object.
 const unsafeGlobalEvalSrc = `(0, eval)("'use strict'; this")`;
 
-export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarget, RedProxyTarget>, endowments?: object): (sourceText: string) => void {
+export default function createSecureEnvironment(options?: EnvironmentOptions): (sourceText: string) => void {
+    const { distortionMap, endowments } = options || {};
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
     const redGlobalThis = runInNewContext(unsafeGlobalEvalSrc);
     const endowmentsDescriptors = getFilteredEndowmentDescriptors(endowments || {});

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -12,7 +12,7 @@ export default function createSecureEnvironment(options?: EnvironmentOptions): (
     const { distortionMap, endowments } = options || ObjectCreate(null);
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
     const redGlobalThis = runInNewContext(unsafeGlobalEvalSrc);
-    const endowmentsDescriptors = getFilteredEndowmentDescriptors(endowments || {});
+    const endowmentsDescriptors = getFilteredEndowmentDescriptors(endowments || ObjectCreate(null));
     const { eval: redIndirectEval } = redGlobalThis;
     const blueGlobalThis = globalThis as any;
     const env = new SecureEnvironment({

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,8 @@ export interface MembraneBroker {
     getRedRef(blue: BlueValue): RedValue | undefined;
     setRefMapEntries(red: RedValue, blue: BlueValue): void;
 }
+
+export interface EnvironmentOptions {
+    distortionMap?: Map<RedProxyTarget, RedProxyTarget>;
+    endowments?: object;
+}

--- a/test/distortions/getter.spec.js
+++ b/test/distortions/getter.spec.js
@@ -13,7 +13,7 @@ const distortionMap = new Map([
     }]
 ]);
 
-const evalScript = createSecureEnvironment(distortionMap, window);
+const evalScript = createSecureEnvironment({ distortionMap, endowments: window });
 
 describe('Getter Function Distortion', () => {
     it('should be invoked when invoked directly', function() {

--- a/test/distortions/methods.spec.js
+++ b/test/distortions/methods.spec.js
@@ -9,7 +9,7 @@ const distortionMap = new Map([
         throw new Error('forbidden');
     }],
 ]);
-const evalScript = createSecureEnvironment(distortionMap, window);
+const evalScript = createSecureEnvironment({ distortionMap, endowments: window });
 
 describe('Method Distortion', () => {
     it('should be invoked when invoked directly', function() {

--- a/test/dom/custom-element.spec.js
+++ b/test/dom/custom-element.spec.js
@@ -9,7 +9,7 @@ class ExternalElement extends HTMLElement {
 customElements.define('x-external', ExternalElement);
 window.refToExternalElement = ExternalElement;
 
-const evalScript = createSecureEnvironment(undefined, window);
+const evalScript = createSecureEnvironment({ endowments: window });
 
 describe('Outer Realm Custom Element', () => {
     it('should be accessible within the sandbox', function() {

--- a/test/dom/custom-elements-extensions.spec.js
+++ b/test/dom/custom-elements-extensions.spec.js
@@ -6,7 +6,7 @@ customElements.define('x-base', Base);
 
 describe('Extending Custom Element', () => {
 
-    const evalScript = createSecureEnvironment(undefined, window);
+    const evalScript = createSecureEnvironment({ endowments: window });
 
     it('should be allowed from blue to red', function() {
         // expect.assertions(1);
@@ -54,8 +54,8 @@ describe('Extending Custom Element', () => {
 
 describe('NS-to-NS custom element extension', () => {
 
-    const evalScriptNS1 = createSecureEnvironment(undefined, window);
-    const evalScriptNS2 = createSecureEnvironment(undefined, window);
+    const evalScriptNS1 = createSecureEnvironment({ endowments: window });
+    const evalScriptNS2 = createSecureEnvironment({ endowments: window });
 
     it('should work when using multiple namespaces in proto-chain', function() {
         // expect.assertions(6);

--- a/test/dom/unforgeables.spec.js
+++ b/test/dom/unforgeables.spec.js
@@ -1,6 +1,6 @@
 import createSecureEnvironment from '../../lib/browser-realm.js';
 
-const evalScript = createSecureEnvironment(undefined, window);
+const evalScript = createSecureEnvironment({ endowments: window });
 
 describe('EventTarget unforgeable', () => {
     it('should be accessible from window', function() {

--- a/test/errors/boundary.spec.js
+++ b/test/errors/boundary.spec.js
@@ -24,7 +24,7 @@ globalThis.boundaryHooks = {
 describe('The Error Boundary', () => {
     it('should preserve identity of errors after a membrane roundtrip', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`boundaryHooks.expose(() => { boundaryHooks.a })`);
         expect(() => {
             sandboxedValue();
@@ -40,7 +40,7 @@ describe('The Error Boundary', () => {
     });
     it('should remap the Outer Realm Error instance to the sandbox errors', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
 
         evalScript(`
             expect(() => {
@@ -60,7 +60,7 @@ describe('The Error Boundary', () => {
     });
     it('should capture throwing from user proxy', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             const revocable = Proxy.revocable(() => undefined, {});
             revocable.revoke();
@@ -77,7 +77,7 @@ describe('The Error Boundary', () => {
         }).toThrowError(Error);
     });
     it('should protect from leaking sandbox errors during evaluation', function() {
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         
         expect(() => {
             evalScript(`
@@ -86,7 +86,7 @@ describe('The Error Boundary', () => {
         }).toThrowError(TypeError);
     });
     it('should protect from leaking sandbox errors during parsing', function() {
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
 
         expect(() => {
             evalScript(`

--- a/test/membrane/array.spec.js
+++ b/test/membrane/array.spec.js
@@ -9,7 +9,7 @@ function saveFoo(arg) {
 
 describe('arrays', () => {
     it('should preserve the length behavior across the membrane', () => {
-        const evalScript = createSecureEnvironment(undefined, { blue, saveFoo, expect });
+        const evalScript = createSecureEnvironment({ endowments: { blue, saveFoo, expect }});
         evalScript(`
             saveFoo(['a', 'b', 'c']);
             expect(blue.length).toBe(3);

--- a/test/membrane/blue-expandos.spec.js
+++ b/test/membrane/blue-expandos.spec.js
@@ -13,7 +13,7 @@ function saveFoo(arg) {
 describe('The blue expandos', () => {
     it('should never be subject to red side mutations', function() {
         // expect.assertions(1);
-        const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+        const evalScript = createSecureEnvironment({ endowments: { Base, saveFoo }});
         evalScript(`
             function mixin(Clazz) {
                 return class extends Clazz {}

--- a/test/membrane/cross-ns-extensions.spec.js
+++ b/test/membrane/cross-ns-extensions.spec.js
@@ -10,7 +10,7 @@ function saveFoo(f) {
     Foo = f;
 }
 
-const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+const evalScript = createSecureEnvironment({ endowments: { Base, saveFoo }});
 evalScript(`
     class Foo extends Base {
         foo() {
@@ -28,7 +28,7 @@ const endowments = {
 describe('The membrane', () => {
     it('should allow expandos on endowments inside the sandbox', function() {
         // expect.assertions(4);
-        const evalScript = createSecureEnvironment(undefined, endowments);
+        const evalScript = createSecureEnvironment({ endowments });
         evalScript(`
             'use strict';
             expect(Foo.prototype.base()).toBe('from base');

--- a/test/membrane/document-all.spec.js
+++ b/test/membrane/document-all.spec.js
@@ -3,7 +3,7 @@ import createSecureEnvironment from '../../lib/browser-realm.js';
 describe('document.all', () => {
     it('should preserve the typeof it since it is a common test for older browsers', function() {
         // expect.assertions(2);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         expect(typeof document.all).toBe("undefined");
         evalScript(`
             expect(typeof document.all).toBe("undefined");
@@ -11,7 +11,7 @@ describe('document.all', () => {
     });
     it('should disable the feature entirely inside the sandbox', function() {
         // expect.assertions(1);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(document.all === undefined).toBeTrue();
         `);

--- a/test/membrane/error.spec.js
+++ b/test/membrane/error.spec.js
@@ -1,7 +1,7 @@
 import createSecureEnvironment from '../../lib/browser-realm.js'
 
 it('[red] non-error objects thrown in red functions', () => {
-    const evalScript = createSecureEnvironment(undefined, { expect })
+    const evalScript = createSecureEnvironment({ endowments: { expect }})
     evalScript(`
         const errorObj = { foo: 'bar' }
         function foo() {
@@ -19,7 +19,7 @@ it('[red] non-error objects thrown in red functions', () => {
 })
 
 it('[red] non-error objects thrown in red constructors', () => {
-    const evalScript = createSecureEnvironment(undefined, { expect })
+    const evalScript = createSecureEnvironment({ endowments: { expect }})
     evalScript(`
         const errorObj = { foo: 'bar' }
         
@@ -40,7 +40,7 @@ it('[red] non-error objects thrown in red constructors', () => {
 })
 
 it('[red] non-error objects thrown in Promise', (done) => {
-    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    const evalScript = createSecureEnvironment({ endowments: { done, expect }})
     evalScript(`
         const error = { foo: 'bar' }
         const p = new Promise(() => {
@@ -56,7 +56,7 @@ it('[red] non-error objects thrown in Promise', (done) => {
 })
 
 it('[red] unhandled promise rejections with non-error objects and red listener', (done) => {
-    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    const evalScript = createSecureEnvironment({ endowments: { done, expect }})
     evalScript(`
         const errorObj = { foo: 'bar' }
 
@@ -77,7 +77,7 @@ it('[red] unhandled promise rejections with non-error objects and red listener',
 })
 
 it('[red] Promise.reject non-error objects', (done) => {
-    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    const evalScript = createSecureEnvironment({ endowments: { done, expect }})
     evalScript(`
         const errorObj = { foo: 'bar' }
 
@@ -92,7 +92,7 @@ it('[red] Promise.reject non-error objects', (done) => {
 })
 
 it('[red] unhandled promise rejections and Promise.reject with non-error objects and red listener', (done) => {
-    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    const evalScript = createSecureEnvironment({ endowments: { done, expect }})
     evalScript(`
         const errorObj = { foo: 'bar' }
 
@@ -116,7 +116,7 @@ it('[red] non-error objects thrown in blue functions', () => {
         throw { foo: 'bar' }
     }
     
-    const evalScript = createSecureEnvironment(undefined, { foo, expect })
+    const evalScript = createSecureEnvironment({ endowments: { foo, expect }})
     evalScript(`
         try {
             foo()
@@ -134,7 +134,7 @@ it('[red] non-error objects thrown in blue constructors', () => {
         }
     }
     
-    const evalScript = createSecureEnvironment(undefined, { Foo, expect })
+    const evalScript = createSecureEnvironment({ endowments: { Foo, expect }})
     evalScript(`
         try {
             new Foo()
@@ -163,7 +163,7 @@ it('[red] blue extended error objects', () => {
         }
     }
     
-    const evalScript = createSecureEnvironment(undefined, { Foo, expect })
+    const evalScript = createSecureEnvironment({ endowments: { Foo, expect }})
     evalScript(`
         try {
             new Foo()
@@ -180,7 +180,7 @@ it('[red] .catch on blue promise', (done) => {
         throw {foo: 'bar'}
     })
 
-    const evalScript = createSecureEnvironment(undefined, { promise, expect, done })
+    const evalScript = createSecureEnvironment({ endowments: { promise, expect, done }})
     evalScript(`
         promise.catch(e => {
             expect(e.foo).toBe('bar')
@@ -191,7 +191,7 @@ it('[red] .catch on blue promise', (done) => {
 })
 
 it('[red] non-error object with null proto', () => {
-    const evalScript = createSecureEnvironment(undefined, { expect })
+    const evalScript = createSecureEnvironment({ endowments: { expect }})
     evalScript(`
         const errorObj = Object.create(null, {foo: {value: 'bar'}})
         try {
@@ -209,7 +209,7 @@ it('[red] non-error object with null proto from blue', () => {
     function foo() {
         throw Object.create(null, {foo: {value: 'bar'}})
     }
-    const evalScript = createSecureEnvironment(undefined, { foo, expect })
+    const evalScript = createSecureEnvironment({ endowments: { foo, expect }})
     evalScript(`
         try {
             foo()
@@ -222,7 +222,7 @@ it('[red] non-error object with null proto from blue', () => {
 })
 
 it('[red] instanceof Error', () => {
-    const evalScript = createSecureEnvironment(undefined, { expect })
+    const evalScript = createSecureEnvironment({ endowments: { expect }})
     evalScript(`
         try {
             throw new Error('foo')
@@ -234,7 +234,7 @@ it('[red] instanceof Error', () => {
 })
 
 it('[red] instanceof extended Error objects', () => {
-    const evalScript = createSecureEnvironment(undefined, { expect })
+    const evalScript = createSecureEnvironment({ endowments: { expect }})
     evalScript(`
         class CustomError extends Error {}
         try {
@@ -247,7 +247,7 @@ it('[red] instanceof extended Error objects', () => {
 })
 
 it('[red] .catch instanceof Error', (done) => {
-    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    const evalScript = createSecureEnvironment({ endowments: { done, expect }})
     evalScript(`
         new Promise((resolve, reject) => {
             reject(new Error('foo'))
@@ -263,7 +263,7 @@ it('[red] instanceof blue Error objects', () => {
     function foo() {
         throw new Error('foo')
     }
-    const evalScript = createSecureEnvironment(undefined, { foo, expect })
+    const evalScript = createSecureEnvironment({ endowments: { foo, expect }})
     evalScript(`
         try {
             foo()
@@ -279,7 +279,7 @@ it('[red] .catch instanceof blue Error objects', (done) => {
         reject(new Error('foo'))
     })
 
-    const evalScript = createSecureEnvironment(undefined, { promise, expect, done })
+    const evalScript = createSecureEnvironment({ endowments: { promise, expect, done }})
     evalScript(`
         promise.catch(e => {
             expect(e instanceof Error).toBe(true)
@@ -296,7 +296,7 @@ it('[blue] .catch on red promise', (done) => {
         promise = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         const error = { foo: 'bar' }
         const p = new Promise(() => {
@@ -323,7 +323,7 @@ it('[blue] unhandled promise rejections listener with red non-error objects', (d
 
     window.addEventListener("unhandledrejection", handler)
 
-    const evalScript = createSecureEnvironment(undefined, {})
+    const evalScript = createSecureEnvironment()
     evalScript(`
         const errorObj = { foo: 'bar' }    
         new Promise((resolve, reject) => {
@@ -338,7 +338,7 @@ it('[blue] non-error objects thrown in red functions', () => {
         fn = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         function foo() {
             throw { foo: 'bar' }
@@ -360,7 +360,7 @@ it('[blue] non-error objects thrown in red consturctors', () => {
         ctor = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         class Foo {
             constructor() {
@@ -384,7 +384,7 @@ it('[blue] red extended error objects', () => {
         ctor = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`    
         class CustomError extends Error {
             constructor(message) {
@@ -421,7 +421,7 @@ it('[blue] non-error objects with null proto from red', () => {
         fn = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         function foo() {
             const errorObj = Object.create(null, {foo: {value: 'bar'}})
@@ -446,7 +446,7 @@ it('[blue] instanceof red error', () => {
         fn = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         function foo() {            
             throw new Error('foo')
@@ -469,7 +469,7 @@ it('[blue] .catch instanceof red error', (done) => {
         promise = arg
     }
 
-    const evalScript = createSecureEnvironment(undefined, { save })
+    const evalScript = createSecureEnvironment({ endowments: { save }})
     evalScript(`
         const promise = new Promise((resolve, reject) => {
             reject(new Error('foo'))

--- a/test/membrane/expandos.spec.js
+++ b/test/membrane/expandos.spec.js
@@ -5,7 +5,7 @@ window.expandable = { x: 1 };
 describe('The membrane', () => {
     it('should allow global inside the sandbox', function() {
         // expect.assertions(4);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expandable.y = 2;
             expect(expandable.y).toBe(2);    

--- a/test/membrane/globals.spec.js
+++ b/test/membrane/globals.spec.js
@@ -3,7 +3,7 @@ import createSecureEnvironment from '../../lib/browser-realm.js';
 describe('The Sandbox', () => {
     it('should allow creation of sandboxed global expandos', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             window.s1 = 'a';
             expect(s1).toBe('a');    
@@ -17,7 +17,7 @@ describe('The Sandbox', () => {
     it('should allow the shadowing of existing globals', function() {
         // expect.assertions(3);
         window.s2 = 'b';
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(s2).toBe('b');
             window.s2 = 'c';

--- a/test/membrane/internal-slot-protection.spec.js
+++ b/test/membrane/internal-slot-protection.spec.js
@@ -4,11 +4,12 @@ describe('membrane', () => {
     it('should prevent attacks that are changing the prototype for impersonation', function() {
         // expect.assertions(4);
         const { set } = Object.getOwnPropertyDescriptor(Element.prototype, 'setAttribute');
-        const evalScript = createSecureEnvironment(new Map(set, function (attributeName, value) {
+        const distortionMap = new Map(set, function (attributeName, value) {
             expect(attributeName).toBe('rel');
             expect(value).toBe('import');
             expect(this instanceof HTMLLinkElement).toBeTrue();
-        }), window);
+        });
+        const evalScript = createSecureEnvironment({ distortionMap, endowments: window });
         evalScript(`
             'use strict';
 

--- a/test/membrane/invariant.spec.js
+++ b/test/membrane/invariant.spec.js
@@ -9,7 +9,7 @@ function saveFoo(arg) {
     FooClazz = arg;
 }
 
-const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+const evalScript = createSecureEnvironment({ endowments: { Base, saveFoo }});
 evalScript(`
     class Foo extends Base {};
     saveFoo(Foo);

--- a/test/membrane/life-red-proxies.spec.js
+++ b/test/membrane/life-red-proxies.spec.js
@@ -11,7 +11,7 @@ const endowments = {
     o,
     expect,
 };
-const evalScript = createSecureEnvironment(undefined, endowments);
+const evalScript = createSecureEnvironment({ endowments });
 
 describe('A Live Red Proxy', () => {
     it('should surface new expandos from blue realm', function() {

--- a/test/membrane/null-protos.spec.js
+++ b/test/membrane/null-protos.spec.js
@@ -12,7 +12,7 @@ function saveFoo(arg) {
 describe('null __proto__', () => {
     it('should work for get trap', function() {
         // expect.assertions(4);
-        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        const evalScript = createSecureEnvironment({ endowments: { bar, saveFoo, expect }});
         evalScript(`
             const foo = Object.create(null, {
                 y: { value: 2 }
@@ -26,7 +26,7 @@ describe('null __proto__', () => {
     });
     it('should work for set trap', function() {
         // expect.assertions(6);
-        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        const evalScript = createSecureEnvironment({ endowments: { bar, saveFoo, expect }});
         evalScript(`
             const foo = Object.create(null, {
                 x: { value: 2 },
@@ -43,7 +43,7 @@ describe('null __proto__', () => {
     });
     it('should work for has trap', function() {
         // expect.assertions(4);
-        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        const evalScript = createSecureEnvironment({ endowments: { bar, saveFoo, expect }});
         evalScript(`
             const foo = Object.create(null, {
                 y: { value: 2, writable: true }

--- a/test/membrane/object-graph-mutations.spec.js
+++ b/test/membrane/object-graph-mutations.spec.js
@@ -3,7 +3,7 @@ import createSecureEnvironment from '../../lib/browser-realm.js';
 describe('The object graph', () => {
     it('should be shadowed by a sandbox', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             'use strict';
 

--- a/test/membrane/object-semantics.spec.js
+++ b/test/membrane/object-semantics.spec.js
@@ -14,7 +14,7 @@ describe('Blue Proxies', () => {
     it('should be preserved the JS Object semantics by allowing writable objects to change', () => {
         'use strict';
         // expect.assertions(9);
-        const evalScript = createSecureEnvironment(undefined, endowments);
+        const evalScript = createSecureEnvironment({ endowments });
         evalScript(`
             'use strict';
             const obj = {

--- a/test/membrane/ownKeys.spec.js
+++ b/test/membrane/ownKeys.spec.js
@@ -6,17 +6,16 @@ function exportData(arg) {
 }
 
 it('does not throw ownKeys trap invariant for classes or strict mode functions', () => {
-  const secureEvalOne = createSecureEnvironment(undefined, { exportData });
+  const secureEvalOne = createSecureEnvironment({ endowments: { exportData }});
   secureEvalOne(`
     exportData([
       class Foo {},
       function() {'use strict'}
     ]);
   `);
-  const secureEvalTwo = createSecureEnvironment(
-    undefined,
-    { exportData, imported: exported }
-  );
+  const secureEvalTwo = createSecureEnvironment({
+    endowments: { exportData, imported: exported }
+  });
   secureEvalTwo(`
     exportData(imported.map(Reflect.ownKeys));
   `);

--- a/test/membrane/promises.spec.js
+++ b/test/membrane/promises.spec.js
@@ -2,7 +2,7 @@ import createSecureEnvironment from "../../lib/browser-realm.js";
 
 describe("Promise", () => {
     it("can be constructed", (done) => {
-        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        const evalScript = createSecureEnvironment({ endowments: { done, expect }});
         evalScript(`
             const p = new Promise(resolve => {
                 resolve(1);
@@ -14,7 +14,7 @@ describe("Promise", () => {
         `);
     });
     it(".resolve() should be supported", (done) => {
-        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        const evalScript = createSecureEnvironment({ endowments: { done, expect }});
         evalScript(`
             const p = Promise.resolve(1);
             p.then((value) => {
@@ -24,7 +24,7 @@ describe("Promise", () => {
         `);
     });
     it(".reject() should be supported", (done) => {
-        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        const evalScript = createSecureEnvironment({ endowments: { done, expect }});
         evalScript(`
             const p = Promise.reject(new Error('foo'));
             p.catch((e) => {
@@ -34,7 +34,7 @@ describe("Promise", () => {
         `);
     });
     it("throw should be supported with errors", (done) => {
-        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        const evalScript = createSecureEnvironment({ endowments: { done, expect }});
         evalScript(`
             const p = new Promise(() => {
                 throw new Error('foo');
@@ -46,7 +46,7 @@ describe("Promise", () => {
         `);
     });
     it("throw should be supported with non-errors", (done) => {
-        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        const evalScript = createSecureEnvironment({ endowments: { done, expect }});
         evalScript(`
             const p = new Promise(() => {
                 throw { foo: 'bar' };

--- a/test/membrane/super.spec.js
+++ b/test/membrane/super.spec.js
@@ -6,7 +6,7 @@ function exportData(arg) {
 }
 
 it('super should behave as expected in sandbox', () => {
-  const secureEvalOne = createSecureEnvironment(undefined, { exportData });
+  const secureEvalOne = createSecureEnvironment({ endowments: { exportData }});
   secureEvalOne(`
     exportData(class Foo {
       constructor() {
@@ -14,10 +14,9 @@ it('super should behave as expected in sandbox', () => {
       }
     });`,
   );
-  const secureEvalTwo = createSecureEnvironment(
-    undefined,
-    { expect, Foo: exported }
-  );
+  const secureEvalTwo = createSecureEnvironment({
+    endowments: { expect, Foo: exported }
+  });
   secureEvalTwo(`
     class Bar extends Foo {
       constructor() {

--- a/test/membrane/symbols.spec.js
+++ b/test/membrane/symbols.spec.js
@@ -7,7 +7,7 @@ globalThis.symbolWithKey = Symbol.for('symbol-with-key');
 describe('Secure Membrane', () => {
     it('should support symbols', () => {
         // expect.assertions(5);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(typeof Symbol() === 'symbol').toBeTrue();
             expect(typeof Symbol.for('x') === 'symbol').toBeTrue();
@@ -19,7 +19,7 @@ describe('Secure Membrane', () => {
     });
     it('should allow access to symbols defined in outer realm', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(typeof globalThis.regularSymbol).toBe('symbol');
             expect(typeof globalThis.symbolWithDescription).toBe('symbol');
@@ -28,7 +28,7 @@ describe('Secure Membrane', () => {
     });
     it('should not leak outer realm global reference via symbols', function() {
         // expect.assertions(2);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(globalThis.regularSymbol.constructor).toBe(Symbol);
             expect(globalThis.regularSymbol.constructor.__proto__.constructor('return this')() === globalThis).toBeTrue();
@@ -36,7 +36,7 @@ describe('Secure Membrane', () => {
     });
     it('should not leak outer realm global reference via Symbol.for()', function() {
         // expect.assertions(3);
-        const evalScript = createSecureEnvironment(undefined, window);
+        const evalScript = createSecureEnvironment({ endowments: window });
         evalScript(`
             expect(typeof Symbol.for('symbol-with-key')).toBe('symbol');
             expect(Symbol.for('symbol-with-key')).toBe(Symbol.for('symbol-with-key'));
@@ -55,7 +55,7 @@ describe('Secure Membrane', () => {
             }
         }
 
-        const secureEval = createSecureEnvironment(undefined, { Base, symbol });
+        const secureEval = createSecureEnvironment({ endowments: { Base, symbol }});
         secureEval(`
             class Bar extends Base {
                 constructor() {


### PR DESCRIPTION
This PR is a non-backward compatible change to accept an options bag when creating a new sandbox, it accepts `endowments` object, `distortionMap` Map and `keepAlive` boolean flag as part of the options bag for browsers. `keepAlive` will be ignored in node.

This PR enables consumers of this library to decide whether or not they want to disconnect the iframe in browsers via `keepAlive`, which defaults to false. For example, they could do this in dev-mode to debug in chrome.