### PR TITLE
fix(environment) add Proxy to ReflectiveIntrinsicObjectNames

### DIFF
--- a/src/intrinsics.ts
+++ b/src/intrinsics.ts
@@ -1,4 +1,5 @@
 import {
+    isObjectLike,
     isUndefined,
     ObjectCreate,
     WeakMapCreate,
@@ -115,6 +116,7 @@ const ReflectiveIntrinsicObjectNames = [
     'EvalError',
     'Function',
     'Object',
+    'Proxy',
     'RangeError',
     'ReferenceError',
     'SyntaxError',
@@ -150,9 +152,11 @@ export function linkIntrinsics(
         const blue = blueIntrinsics[name];
         const red = redIntrinsics[name];
         // new intrinsics might not be available in some browsers, e.g.: AggregateError
-        if (!isUndefined(blue)) {
+        if (isObjectLike(blue)) {
             env.setRefMapEntries(red, blue);
-            env.setRefMapEntries(red.prototype, blue.prototype);
+            if (isObjectLike(blue.prototype)) {
+                env.setRefMapEntries(red.prototype, blue.prototype);
+            }
         }
     }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -79,4 +79,12 @@ export function isFunction(obj: any): obj is Function {
     return typeof obj === 'function';
 }
 
+export function isObject(obj: any): boolean {
+    return typeof obj === 'object' && obj !== null;
+}
+
+export function isObjectLike(obj: any): boolean {
+    return isObject(obj) || isFunction(obj);
+}
+
 export const emptyArray: [] = [];

--- a/test/membrane/reversed-proxy-constructor.spec.js
+++ b/test/membrane/reversed-proxy-constructor.spec.js
@@ -1,0 +1,32 @@
+import createSecureEnvironment from "../../lib/browser-realm.js";
+
+describe("Reversed Proxy constructor", () => {
+    it("can be constructed", () => {
+        const evalScript = createSecureEnvironment({
+            endowments: {
+                test({ Proxy }) {
+                    const p = new Proxy({}, {
+                        get() { return 1 }
+                    });
+                    expect(p.a).toBe(1);
+                },
+            },
+        });
+        evalScript(`test({ Proxy });`);
+    });
+    it(".revocable() should be supported", () => {
+        const evalScript = createSecureEnvironment({
+            endowments: {
+                test({ Proxy }) {
+                    const { proxy, revoke } = Proxy.revocable({}, {
+                        get() { return 1 }
+                    });
+                    expect(proxy.a).toBe(1);
+                    revoke();
+                    expect(() => proxy.a).toThrowError(TypeError);
+                },
+            },
+        });
+        evalScript(`test({ Proxy });`);
+    });
+});


### PR DESCRIPTION
I believe this is all that's needed to avoid wrapping `Proxy`.